### PR TITLE
Fix the #fork? spec

### DIFF
--- a/lib/scm_checkout.rb
+++ b/lib/scm_checkout.rb
@@ -134,9 +134,8 @@ class GithubCheckout < ScmCheckout
   def fork?
     return @is_fork unless @is_fork.nil?
     if !File.directory?(File.join(settings.repos, name))
-      json = JSON.parse(open("https://api.github.com/users/#{username}/repos").read)
-      proj_json = json.find {|s| s["name"] == project }
-      @is_fork = proj_json["fork"] if proj_json
+      json = JSON.parse(open("https://api.github.com/repos/#{username}/#{project}").read)
+      @is_fork = json["fork"] if json
     else
       @is_fork = true
     end

--- a/spec/github_checkout_spec.rb
+++ b/spec/github_checkout_spec.rb
@@ -60,7 +60,7 @@ describe GithubCheckout do
 
     it "should return true for non-master repo" do
       File.should_receive(:directory?).and_return(false)
-      git("git://github.com/lsegal/rails")
+      git("git://github.com/lsegal/redcarpet")
       @git.should be_fork
     end
   end


### PR DESCRIPTION
So this spec was failing as your fork of rails no longer exists . . .

I also changed to using the single repo endpoint, I guess its better to make a smaller request.